### PR TITLE
Reenvío hito 2

### DIFF
--- a/proyectos/hito-2.md
+++ b/proyectos/hito-2.md
@@ -49,7 +49,7 @@ Añade debajo enlaces a tu proyecto
 | RUIZ LOPEZ, MANUEL | [Proyecto](https://github.com/manoliot/tiempo-aemet-bot) | 0.2 |
 | SANCHEZ JIMENEZ, DAVID| [Weahter-App](https://github.com/Koltharius/Weather_App) | 0.4 |
 | SANCHEZ PALOMINO, ALVARO| [Proyecto](https://github.com/Alvarosanpal/Proyecto_IV) | 1.2 |
-| SANCHEZ DE LECHINA TEJADA, JESUS| [Duckpiler](https://github.com/jojelupipa/Duckpiler) |0.3 |
+| SANCHEZ DE LECHINA TEJADA, JESUS| [Duckpiler](https://github.com/jojelupipa/Duckpiler) |0.3.1 **Reenvío** |
 | SARRIONANDIA DE LEÓN, AITOR|[Proyecto](https://github.com/aitorSDL/proyecto-iv-1819)|1.1|
 | TALAVERA MENDOZA, FERNANDO RAFAEL| [Proyecto](https://github.com/Thejokeri/IV-18-19-Proyecto) | 1.0 |
 | TOLEDO AGUILERA, FRANCISCO MIGUEL| [Proyecto](https://github.com/maikeltoledo/IV-18-19-Proyecto) | 0.3 |


### PR DESCRIPTION
Actualizado el link al que enlazaba el badge de travis
(Soluciona el issue [#13 del proyecto](https://github.com/jojelupipa/Duckpiler/issues/13) 